### PR TITLE
poc: try to use go-task instead of makefile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,29 @@
+# https://taskfile.dev
+
+version: '2'
+
+vars:
+  APPNAME:
+    sh: basename $(go list)
+  COMMIT:
+    sh: git rev-parse --verify HEAD
+  DATE:
+    sh: date +%FT%T%z
+  VERSION: '{{.VERSION | default "snapshot" }}'
+  GOPATH:
+    sh: go env GOPATH
+  GO_LDFLAGS: |
+      -X main.appName={{.APPNAME}} \
+      -X main.buildVersion={{.VERSION}} \
+      -X main.buildCommit={{.COMMIT}} \
+      -X main.buildDate={{.DATE}}
+  DOCKER_ACCOUNT: thiht
+  DOCKER_IMAGE: "{{.DOCKER_ACCOUNT}}/{{.APPNAME}}"
+
+tasks:
+  start:
+    cmds:
+      - go install -ldflags="{{.GO_LDFLAGS}}" .
+      - smocker --log-level=info
+    sources:
+      - ./**/*.go

--- a/server/middlewares.go
+++ b/server/middlewares.go
@@ -58,7 +58,6 @@ func (s *mockServer) historyMiddleware() echo.MiddlewareFunc {
 			}
 
 			response := c.Response()
-
 			var body interface{}
 			var tmp map[string]interface{}
 			if err := json.Unmarshal(responseBody.Bytes(), &tmp); err != nil {


### PR DESCRIPTION
Quite sexy but not very maintained and I have problems with the livereload even when server gracefully stop is handled correctly.
It's also the mess to install because master doesn't compile using go modules

Maybe we should try to find an alternative if we want to replace the Makefile