### PR TITLE
add cookie banner on documentation

### DIFF
--- a/docs/.vuepress/components/CookieLaw.vue
+++ b/docs/.vuepress/components/CookieLaw.vue
@@ -1,0 +1,38 @@
+<template>
+  <footer>
+    <cookie-law theme="vuepress">
+      <div slot="message">
+        This site uses Google Analytics, a web analytics service provided by
+        Google, Inc. Google Analytics sets a cookie in order to evaluate our use
+        of our website and compile reports on user activity.
+      </div>
+    </cookie-law>
+  </footer>
+</template>
+
+<script>
+import CookieLaw from "vue-cookie-law";
+export default {
+  components: { CookieLaw },
+};
+</script>
+
+<style>
+.Cookie--vuepress {
+  background: rgb(255, 255, 237);
+  border-top: 1px solid #fff2e2;
+  padding: 1.5em;
+}
+
+.Cookie--vuepress .Cookie__button {
+  color: #fff;
+  background: #3eaf7c;
+  padding: 0.5em;
+  border: none;
+  border-radius: 4px;
+}
+
+.Cookie--vuepress .Cookie__button:hover {
+  background: #4abf8a;
+}
+</style>

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -8,6 +8,7 @@ const analytics = process.env.GA_ID
 module.exports = {
   title: "Smocker",
   description: "Smocker is a simple and efficient HTTP mock server.",
+  globalUIComponents: ["CookieLaw"],
   head: [
     [
       "link",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "ts-jest": "^26.1.1",
     "tslib": "^2.0.0",
     "typescript": "^3.8.3",
+    "vue-cookie-law": "^1.13.3",
     "vuepress": "^1.8.2",
     "vuepress-plugin-fulltext-search": "^2.2.0",
     "vuepress-plugin-mermaidjs": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11825,6 +11825,11 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tiny-cookie@^2.1.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/tiny-cookie/-/tiny-cookie-2.3.2.tgz#3b5fb4e0888cfa0b4728d5f6b7be3d3a88e6a5f0"
+  integrity sha512-qbymkVh+6+Gc/c9sqnvbG+dOHH6bschjphK3SHgIfT6h/t+63GBL37JXNoXEc6u/+BcwU6XmaWUuf19ouLVtPg==
+
 tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
@@ -12415,6 +12420,13 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vue-cookie-law@^1.13.3:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/vue-cookie-law/-/vue-cookie-law-1.13.3.tgz#c4fc5d9dd66772d4043c4f140790a0e502caabbc"
+  integrity sha512-n5ef5/dAB4cyUz6OaolYZEeyfV/fcsVU/RCTT/aHXcyjNbXf7EU2TgaOlMwu+cTOjdn5tBJKyKP6lr6IOUf9bg==
+  dependencies:
+    tiny-cookie "^2.1.1"
 
 vue-hot-reload-api@^2.3.0:
   version "2.3.4"


### PR DESCRIPTION
<img width="1440" alt="Capture d’écran 2021-06-29 à 22 29 08" src="https://user-images.githubusercontent.com/2796344/123863353-c9f38b80-d929-11eb-90b6-d6cf3a3d7adf.png">

j'ai mis la bannière jaune très clair, je sais pas ce que t'en penses. Je peux la mettre en blanc ou autre sinon