### PR TITLE
docs: fix Go template Request type url

### DIFF
--- a/docs/technical-documentation/mock-definition.md
+++ b/docs/technical-documentation/mock-definition.md
@@ -248,7 +248,7 @@ dynamic_response:
 
 ### Dynamic responses using Go templates
 
-A dynamic response using Go templates must generate a YAML string representing a `response` object. Some parts of the response can be generated dynamically. In Go templates, the [`Request`](https://godoc.org/github.com/Thiht/smocker/types#Request) variable is available, containing the values of the current request. The utility library [Masterminds/sprig](https://masterminds.github.io/sprig/) is also fully available.
+A dynamic response using Go templates must generate a YAML string representing a `response` object. Some parts of the response can be generated dynamically. In Go templates, the [`Request`](https://pkg.go.dev/github.com/Thiht/smocker/server/types#Request) variable is available, containing the values of the current request. The utility library [Masterminds/sprig](https://masterminds.github.io/sprig/) is also fully available.
 
 The easiest way to write a dynamic response using Go templates is to first write the static response you want:
 


### PR DESCRIPTION
Hi, the `Request` type [link](https://godoc.org/github.com/Thiht/smocker/types#Request) in the docs is a page not found, this should fix it with a valid [link](https://pkg.go.dev/github.com/Thiht/smocker/server/types#Request) (It's the same used in the Lua template section)