### PR TITLE
Add CLI option -mocks-directory 

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func parseConfig() (c config.Config) {
 	flag.StringVar(&c.StaticFiles, "static-files", ".", "The location of the static files to serve (index.html, etc.)")
 	flag.IntVar(&c.HistoryMaxRetention, "history-retention", 0, "The maximum number of calls to keep in the history by sessions (0 = infinity)")
 	flag.StringVar(&c.PersistenceDirectory, "persistence-directory", "", "If defined, the directory where the sessions will be synchronized")
+	flag.StringVar(&c.MocksDirectory, "mocks-directory", "", "If defined, the directory use to load the mocks at server start")
 	flag.Parse()
 	return
 }

--- a/server/admin_server.go
+++ b/server/admin_server.go
@@ -35,6 +35,15 @@ func Serve(config config.Config) {
 	adminServerEngine.Use(recoverMiddleware(), loggerMiddleware(), middleware.Gzip())
 
 	mockServerEngine, mockServices := NewMockServer(config)
+
+	// Autoload mocks at start
+	if config.MocksDirectory != "" {
+		log.WithField("port", config.ConfigListenPort).Infof("Loading mocks from %s", config.MocksDirectory)
+		if err := mockServices.Load(config.MocksDirectory); err != nil {
+			log.WithField("port", config.ConfigListenPort).Fatal(err)
+		}
+	}
+
 	graphServices := services.NewGraph()
 	handler := handlers.NewAdmin(mockServices, graphServices)
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	StaticFiles          string
 	HistoryMaxRetention  int
 	PersistenceDirectory string
+	MocksDirectory       string
 	Build                Build
 }
 


### PR DESCRIPTION
If not empty loads all the mocks from files (YAML/JSON)  in a folder at startup.

Can be used to create dedicated mocks docker image from the smocker official image.