### PR TITLE
Issue #208: Be able to ignore order of elements in JSON lists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/facebookgo/stats v0.0.0-20151006221625-1b76add642e4 // indirect
 	github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 // indirect
+	github.com/kinbiko/jsonassert v1.1.0-beta // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/labstack/echo v3.3.10+incompatible

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,10 @@ github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/kinbiko/jsonassert v1.0.2 h1:UzNDYv5K8UsSHXS3Opsf0ZNz2NQCHl96OC3dlTytUtE=
+github.com/kinbiko/jsonassert v1.0.2/go.mod h1:QRwBwiAsrcJpjw+L+Q4WS8psLxuUY+HylVZS/4j74TM=
+github.com/kinbiko/jsonassert v1.1.0-beta h1:lxEKdQvYstTzFmYdWH+zXYyLOswOP6dRqJ898jdolsE=
+github.com/kinbiko/jsonassert v1.1.0-beta/go.mod h1:QRwBwiAsrcJpjw+L+Q4WS8psLxuUY+HylVZS/4j74TM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/tests/data/matcher_mock_list.yml
+++ b/tests/data/matcher_mock_list.yml
@@ -24,7 +24,7 @@
     body:
       matcher: ShouldEqualJSON
       value: >
-        {"id": 1}
+        {"id": 1, "array": ["<<UNORDERED>>", "foo", "bar", "baz"]}
   response:
     headers:
       Content-Type: application/json

--- a/tests/features/use_mocks.yml
+++ b/tests/features/use_mocks.yml
@@ -104,7 +104,7 @@ testcases:
         method: DELETE
         url: http://localhost:8080/test
         body: >
-          {"id": 1}
+          {"id": 1, "array": ["bar", "baz", "foo"]}
         assertions:
           - result.statuscode ShouldEqual 200
           - result.bodyjson.message ShouldEqual test3


### PR DESCRIPTION
Replace smartystreets ShouldEqualJSON by a custom one using https://github.com/kinbiko/jsonassert which handles unordered list in JSON