### PR TITLE
Init mocks on Docker startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,13 @@ COPY client/ ./client/
 RUN yarn build
 
 FROM alpine
+RUN apk add --no-cache bash curl
 WORKDIR /opt
 EXPOSE 8080 8081
 COPY --from=build-backend /go/src/github.com/Thiht/smocker/build/* /opt/
 COPY --from=build-frontend /wd/build/* /opt/
+
+COPY docker-entrypoint.sh /opt/docker-entrypoint.sh
+
+ENTRYPOINT ["/opt/docker-entrypoint.sh"]
 CMD ["/opt/smocker"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The documentation is available on [smocker.dev](https://smocker.dev).
   - [User Interface](#user-interface)
 - [Usage](#usage)
   - [Hello, World!](#hello-world)
+  - [Initializing Smocker in Docker](#initializing-smocker-in-docker)
+    - [Example](#example)
 - [Development](#development)
   - [Backend](#backend)
   - [Frontend](#frontend)
@@ -133,6 +135,43 @@ curl -XPOST localhost:8081/reset
 ```
 
 For more advanced usage, please read the [project's documentation](https://smocker.dev).
+
+### Initializing Smocker in Docker
+
+By placing files in `/docker-entrypoint-init.d` (or an alternate path defined in `SMOCKER_INIT_SCRIPTS_PATH`), you can configure the fresh instance on startup.
+
+- Any files with extension `yml` or `yaml` will be loaded as mocks
+- Any files with extension `sh` will be executed
+
+You can include more than one file and these files should be executed in alphabetical order.
+
+#### Example
+
+Lets say we have a project structured like this:
+
+```
+.
+├── docker-compose.yml
+└── mocks
+    └── helloworld.yml
+```
+
+```yaml
+# docker-compose.yml
+version: '3'
+
+services:
+  smocker:
+    image: thiht/smocker
+    ports:
+      - '8080:8080'
+      - '8081:8081'
+    volumes:
+      - './mocks:/docker-entrypoint-init.d'
+```
+
+This would load the mocks in `mocks/helloworld.yml` automatically on startup.
+
 
 ## Development
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -meo pipefail
+
+if [[ ! $SMOCKER_INIT_SCRIPTS_PATH ]]
+then
+  SMOCKER_INIT_SCRIPTS_PATH=/docker-entrypoint-init.d
+fi
+
+if [[ ! $SMOCKER_CONFIG_LISTEN_PORT ]]
+then
+  SMOCKER_CONFIG_LISTEN_PORT=8081
+fi
+
+_wait_server_started() {
+  timeout 30 sh -c \
+    "until curl -sSf localhost:$SMOCKER_CONFIG_LISTEN_PORT/version > /dev/null 2>&1; do
+      sleep 1
+    done"
+}
+
+_reset_mocks() {
+  curl -sSf -XPOST "localhost:$SMOCKER_CONFIG_LISTEN_PORT/reset?force=true" > /dev/null 2>&1
+}
+
+_run_init() {
+  for f in $SMOCKER_INIT_SCRIPTS_PATH/*; do
+    case "$f" in
+      *.sh)
+        echo "$0: running $f"
+        # run script
+        . "$f" ;;
+      *.yml|*.yaml)
+        echo "$0: uploading $f"
+        # upload mock via api
+        curl -sSf -XPOST \
+          --header "Content-Type: application/x-yaml" \
+          --data-binary "@$f" \
+          "localhost:$SMOCKER_CONFIG_LISTEN_PORT/mocks" \
+          > /dev/null 2>&1 ;;
+      *)
+        echo "$0: ignoring $f" ;;
+    esac
+  done
+}
+
+# start process in background
+exec "$@" &
+
+if [[ -d $SMOCKER_INIT_SCRIPTS_PATH ]]
+then
+  _wait_server_started
+  _reset_mocks
+  _run_init
+fi
+
+# bring process back to foreground
+fg %1 > /dev/null

--- a/docs/technical-documentation/arguments.md
+++ b/docs/technical-documentation/arguments.md
@@ -4,12 +4,13 @@ Smoker can be parameterized through several arguments.
 
 The list of existing Smocker parameters is:
 
-| Flag                      | Environment Variable              | Default  | Description                                                                                      |
-| ------------------------- | --------------------------------- | :------: | ------------------------------------------------------------------------------------------------ |
-| `config-base-path`        | `SMOCKER_CONFIG_BASE_PATH`        |  **/**   | Used to deploy Smocker under a sub-path of a domain                                              |
-| `config-listen-port`      | `SMOCKER_CONFIG_LISTEN_PORT`      | **8081** | Port exposed by Smocker's API which is used to administrate Smocker                              |
-| `mock-server-listen-port` | `SMOCKER_MOCK_SERVER_LISTEN_PORT` | **8080** | Port exposed by Smocker's mock server where should be redirected your HTTP calls                 |
-| `static-files`            | `SMOCKER_STATIC_FILES`            |  **.**   | The location of the static files to serve for the UI (index.html, etc.)                          |
-| `log-level`               | `SMOCKER_LOG_LEVEL`               | **info** | The log level of Smocker, Values: `panic`, `fatal`, `error`, `warning`, `info`, `debug`, `trace` |
-| `history-retention`       | `SMOCKER_HISTORY_RETENTION`       |  **0**   | The maximum number of calls to keep in the history by sessions (0 = infinity)                    |
-| `persistence-directory`   | `SMOCKER_PERSISTENCE_DIRECTORY`   |  **""**  | If defined, the directory where the sessions will be synchronized                                |
+| Flag                      | Environment Variable              |            Default            | Description                                                                                      |
+| ------------------------- | --------------------------------- | :---------------------------: | ------------------------------------------------------------------------------------------------ |
+| `config-base-path`        | `SMOCKER_CONFIG_BASE_PATH`        |             **/**             | Used to deploy Smocker under a sub-path of a domain                                              |
+| `config-listen-port`      | `SMOCKER_CONFIG_LISTEN_PORT`      |           **8081**            | Port exposed by Smocker's API which is used to administrate Smocker                              |
+| `mock-server-listen-port` | `SMOCKER_MOCK_SERVER_LISTEN_PORT` |           **8080**            | Port exposed by Smocker's mock server where should be redirected your HTTP calls                 |
+| `static-files`            | `SMOCKER_STATIC_FILES`            |             **.**             | The location of the static files to serve for the UI (index.html, etc.)                          |
+| `log-level`               | `SMOCKER_LOG_LEVEL`               |           **info**            | The log level of Smocker, Values: `panic`, `fatal`, `error`, `warning`, `info`, `debug`, `trace` |
+| `history-retention`       | `SMOCKER_HISTORY_RETENTION`       |             **0**             | The maximum number of calls to keep in the history by sessions (0 = infinity)                    |
+| `persistence-directory`   | `SMOCKER_PERSISTENCE_DIRECTORY`   |            **""**             | If defined, the directory where the sessions will be synchronized                                |
+|                           | `SMOCKER_INIT_SCRIPTS_PATH`       | **/docker-entrypoint-init.d** | If directory exists, scripts will run and mocks will be uploaded                                 |


### PR DESCRIPTION
## Purpose

There are a few active discussions on being able to initialize mocks or configure Smocker on startup (https://github.com/Thiht/smocker/issues/217, https://github.com/Thiht/smocker/pull/214) and this is another proposed approach.

This only applies to Docker-based workflows, but the implementation is more straightforward without touching the actual core codebase.

## Approach

The main idea is using an Entrypoint script to start the server process in the background, run some configuration code, then restore the process to the foreground. This pattern is described in the [official Docker docs](https://docs.docker.com/config/containers/multi-service_container/). It's also used in practice in [postgres](https://github.com/docker-library/postgres/blob/master/14/alpine/docker-entrypoint.sh#L156-L182), [mysql](https://github.com/docker-library/mysql/blob/master/8.0/docker-entrypoint.sh#L56-L82), [localstack](https://github.com/localstack/localstack/blob/v0.12.18/bin/docker-entrypoint.sh#L53-L68) etc.

Note: `bash` needs to be used instead of the default bourne shell in alpine because of some issues when attempting to work with background jobs. If you change the Entrypoint shebang to `#!/bin/sh`, there will be an error.
```
$ docker-compose up
Starting smocker_smocker_1 ... done
Attaching to smocker_smocker_1
smocker_1  | /opt/docker-entrypoint.sh: set: line 3: can't access tty; job control turned off
smocker_1  | time="2021-10-03T17:46:24Z" level=info msg="Setting log level" log-level=warning
smocker_1  | /opt/docker-entrypoint.sh: uploading /docker-entrypoint-init.d/helloworld.yml
smocker_1  | /opt/docker-entrypoint.sh: fg: line 58: job %1 not created under job control
smocker_smocker_1 exited with code 2
```