### PR TITLE
Resolve security vulnerability and upgrade to go1.18 CVE-2022-27191

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: '^1.17.0'
+          go-version: '^1.18.0'
 
       - run: yarn install --frozen-lockfile
 
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: '^1.17.0'
+          go-version: '^1.18.0'
 
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine AS build-backend
+FROM golang:1.18-alpine AS build-backend
 RUN apk add --no-cache make
 ARG VERSION=snapshot
 ARG COMMIT


### PR DESCRIPTION
Upgrade go to 1.18 to resolve vulnerability [CVE-2022-27191](https://nvd.nist.gov/vuln/detail/CVE-2022-27191)