### PR TITLE
use atomic to fix mock timesCount counter

### DIFF
--- a/server/handlers/admin.go
+++ b/server/handlers/admin.go
@@ -120,7 +120,7 @@ func (a *Admin) VerifySession(c echo.Context) error {
 		if !mock.Verify() {
 			failedMocks = append(failedMocks, mock)
 		}
-		if mock.State.TimesCount == 0 {
+		if *mock.State.TimesCount == 0 {
 			unusedMocks = append(unusedMocks, mock)
 		}
 	}

--- a/server/handlers/mocks_test.go
+++ b/server/handlers/mocks_test.go
@@ -1,0 +1,84 @@
+package handlers_test
+
+import (
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Thiht/smocker/server"
+	"github.com/Thiht/smocker/server/config"
+	"github.com/Thiht/smocker/server/types"
+)
+
+func TestMocks_GenericHandler(t *testing.T) {
+	server, mocks := server.NewMockServer(config.Config{
+		LogLevel:             "panic",
+		ConfigListenPort:     8081,
+		ConfigBasePath:       "/",
+		MockServerListenPort: 8080,
+		StaticFiles:          ".",
+		Build: config.Build{
+			AppName:      "smocker",
+			BuildVersion: "dev",
+			BuildDate:    time.Now().String(),
+		},
+	})
+	session := mocks.NewSession("test")
+	_, err := mocks.AddMock(session.ID, &types.Mock{
+		Request: types.MockRequest{
+			Method: types.StringMatcher{Matcher: "ShouldMatch", Value: "GET"},
+			Path:   types.StringMatcher{Matcher: "ShouldMatch", Value: "/api/v1"},
+		},
+		Response: &types.MockResponse{
+			Status: 200,
+			Body:   "test",
+		},
+		Context: &types.MockContext{
+			Times: 60000,
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %s", err)
+	}
+
+	go func() {
+		if err := server.ListenAndServe(); err != http.ErrServerClosed {
+			t.Errorf("expected no error, got %s", err)
+		}
+	}()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(20)
+	for i := 0; i < 20; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 3000; j++ {
+				resp, err := http.Get("http://localhost:8080/api/v1")
+				if err != nil {
+					t.Errorf("expected no error, got %s", err)
+				}
+
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Errorf("expected no error, got %s", err)
+				}
+
+				if resp.StatusCode != 200 {
+					t.Errorf("expected status code 200, got %d", resp.StatusCode)
+				}
+				if string(body) != "test" {
+					t.Errorf("expected body to be 'test', got %s", string(body))
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	calls := session.Clone().Mocks.Clone()[0].State.TimesCount
+	if *calls != 60000 {
+		t.Errorf("expected 60000 calls, got %d", calls)
+	}
+}

--- a/server/types/mock.go
+++ b/server/types/mock.go
@@ -68,6 +68,7 @@ func (m *Mock) Init() {
 	m.State = &MockState{
 		CreationDate: time.Now(),
 		ID:           shortid.MustGenerate(),
+		TimesCount:   new(uint64),
 	}
 
 	if m.Context == nil {
@@ -77,7 +78,7 @@ func (m *Mock) Init() {
 
 func (m *Mock) Verify() bool {
 	isTimesDefined := m.Context.Times > 0
-	hasBeenCalledRightNumberOfTimes := m.State.TimesCount == m.Context.Times
+	hasBeenCalledRightNumberOfTimes := *m.State.TimesCount == uint64(m.Context.Times)
 	return !isTimesDefined || hasBeenCalledRightNumberOfTimes
 }
 
@@ -89,7 +90,7 @@ func (m *Mock) CloneAndReset() *Mock {
 			ID:           m.State.ID,
 			CreationDate: time.Now(),
 			Locked:       m.State.Locked,
-			TimesCount:   0,
+			TimesCount:   new(uint64),
 		},
 		DynamicResponse: m.DynamicResponse,
 		Proxy:           m.Proxy,
@@ -272,7 +273,7 @@ type MockContext struct {
 
 type MockState struct {
 	ID           string    `json:"id" yaml:"id"`
-	TimesCount   int       `json:"times_count" yaml:"times_count"`
+	TimesCount   *uint64   `json:"times_count" yaml:"times_count"`
 	Locked       bool      `json:"locked" yaml:"locked"`
 	CreationDate time.Time `json:"creation_date" yaml:"creation_date"`
 }


### PR DESCRIPTION
Fix for the issue https://github.com/Thiht/smocker/issues/272


One of the issues I see in my test, that it generates a lot of logs, but I can't disable it without unrelated changes in `server.NewMockServer`