### PR TITLE
ARM support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY Makefile main.go ./
 COPY server/ ./server/
 RUN make VERSION=$VERSION COMMIT=$COMMIT RELEASE=1 build
 
-FROM node:16-alpine AS build-frontend
+FROM node:16-bullseye AS build-frontend
 WORKDIR /wd
 ENV PARCEL_WORKERS 1
 # node-gyp dependencies: https://github.com/nodejs/node-gyp#on-unix

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ clean:
 
 .PHONY: build-docker
 build-docker:
-	docker buildx build --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --tag $(DOCKER_IMAGE):latest --platform linux/arm/v7,linux/arm64,linux/amd64 .
+	docker buildx build --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --tag $(DOCKER_IMAGE):latest --platform linux/arm64,linux/amd64 .
 	docker tag $(DOCKER_IMAGE) $(DOCKER_IMAGE):$(DOCKER_TAG)
 
 .PHONY: start-docker

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ clean:
 
 .PHONY: build-docker
 build-docker:
-	docker build --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --tag $(DOCKER_IMAGE):latest .
+	docker buildx build --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --tag $(DOCKER_IMAGE):latest --platform linux/arm/v7,linux/arm64,linux/amd64 .
 	docker tag $(DOCKER_IMAGE) $(DOCKER_IMAGE):$(DOCKER_TAG)
 
 .PHONY: start-docker


### PR DESCRIPTION
Fixes build problems with `yarn` and missing `glibc` by using Debian instead of problematic Alpine. It is a bigger image but is used for the build phase only, so it shouldn't be a problem.

Also adding support for multiple architecture docker image in GH actions so the next release should automatically support ARM MacBooks out of the box.