### PR TITLE
fix response body when using go_template_json

### DIFF
--- a/server/templates/go_template.go
+++ b/server/templates/go_template.go
@@ -64,14 +64,15 @@ func (*goTemplateJsonEngine) Execute(request types.Request, script string) (*typ
 		return nil, fmt.Errorf("failed to unmarshal response from dynamic template: %w", err)
 	}
 
-	body := tmplResult["body"]
-	if _, ok := body.(string); !ok {
-		b, err := json.Marshal(body)
-		if err != nil {
-			log.WithError(err).Error("Failed to marshal response body as JSON")
-			return nil, fmt.Errorf("failed to marshal response body as JSON: %w", err)
+	if body := tmplResult["body"]; body != nil {
+		if _, ok := body.(string); !ok {
+			b, err := json.Marshal(body)
+			if err != nil {
+				log.WithError(err).Error("Failed to marshal response body as JSON")
+				return nil, fmt.Errorf("failed to marshal response body as JSON: %w", err)
+			}
+			tmplResult["body"] = string(b)
 		}
-		tmplResult["body"] = string(b)
 	}
 
 	b, err := json.Marshal(tmplResult)


### PR DESCRIPTION
Check that body is not nil before serializing it to json.
This fixes an issue where a mock like this
```yaml
- request:
    method: GET
    path: /foo
  dynamic_response:
    engine: go_template_json
    script: |
      {
        "status": 302,
        "headers": {"Location": "https://example.org/"}
      }
```
returns literal `null` as a response body instead of an empty body.

PS: to be honest, I think this entire `if` block is redundant because it makes the behavior inconsistent between dynamic-response mocks and static-response mocks: in static-response mocks we only allow strings as `body` and don't convert arbitrary objects into strings.
