### PR TITLE
feat: add ability to provide own mock id

### DIFF
--- a/server/handlers/admin.go
+++ b/server/handlers/admin.go
@@ -72,10 +72,10 @@ func (a *Admin) AddMocks(c echo.Context) error {
 	}
 
 	for _, mock := range mocks {
-		if mock.State.ID != "" { // user has defined own mock ID
-			_, err := a.mocksServices.GetMockByID(sessionID, mock.State.ID)
+		if mock.MockID != "" { // user has defined own mock ID
+			_, err := a.mocksServices.GetMockByID(sessionID, mock.MockID)
 			if err == nil {
-				return echo.NewHTTPError(http.StatusConflict, "Mock ID: "+mock.State.ID+" already exists.")
+				return echo.NewHTTPError(http.StatusConflict, "Mock ID: "+mock.MockID+" already exists.")
 			}
 
 			if err != types.MockNotFound {

--- a/server/handlers/admin.go
+++ b/server/handlers/admin.go
@@ -72,6 +72,17 @@ func (a *Admin) AddMocks(c echo.Context) error {
 	}
 
 	for _, mock := range mocks {
+		if mock.State.ID != "" { // user has defined own mock ID
+			_, err := a.mocksServices.GetMockByID(sessionID, mock.State.ID)
+			if err == nil {
+				return echo.NewHTTPError(http.StatusConflict, "Mock ID: "+mock.State.ID+" already exists.")
+			}
+
+			if err != types.MockNotFound {
+				return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+			}
+		}
+
 		if _, err := a.mocksServices.AddMock(sessionID, mock); err != nil {
 			return echo.NewHTTPError(http.StatusNotFound, err.Error())
 		}

--- a/server/types/mock.go
+++ b/server/types/mock.go
@@ -65,9 +65,13 @@ func (m *Mock) Validate() error {
 }
 
 func (m *Mock) Init() {
-	m.State = &MockState{
-		CreationDate: time.Now(),
-		ID:           shortid.MustGenerate(),
+	if m.State != nil && m.State.ID != "" {
+		m.State.CreationDate = time.Now()
+	} else {
+		m.State = &MockState{
+			CreationDate: time.Now(),
+			ID:           shortid.MustGenerate(),
+		}
 	}
 
 	if m.Context == nil {

--- a/server/types/mock.go
+++ b/server/types/mock.go
@@ -24,6 +24,7 @@ func (m Mocks) Clone() Mocks {
 }
 
 type Mock struct {
+	MockID          string               `json:"mockId,omitempty" yaml:"mockId"`
 	Request         MockRequest          `json:"request,omitempty" yaml:"request"`
 	Response        *MockResponse        `json:"response,omitempty" yaml:"response,omitempty"`
 	Context         *MockContext         `json:"context,omitempty" yaml:"context,omitempty"`
@@ -65,13 +66,13 @@ func (m *Mock) Validate() error {
 }
 
 func (m *Mock) Init() {
-	if m.State != nil && m.State.ID != "" {
-		m.State.CreationDate = time.Now()
+	m.State = &MockState{
+		CreationDate: time.Now(),
+	}
+	if m.MockID != "" {
+		m.State.ID = m.MockID
 	} else {
-		m.State = &MockState{
-			CreationDate: time.Now(),
-			ID:           shortid.MustGenerate(),
-		}
+		m.State.ID = shortid.MustGenerate()
 	}
 
 	if m.Context == nil {

--- a/tests/data/basic_mock_with_id.yml
+++ b/tests/data/basic_mock_with_id.yml
@@ -1,0 +1,8 @@
+- request:
+    path: /test
+  response:
+    headers:
+      Content-Type: application/json
+    body: >
+      {"message": "test"}
+  mockId: "1"

--- a/tests/features/use_mocks_with_own_id.yml
+++ b/tests/features/use_mocks_with_own_id.yml
@@ -1,0 +1,33 @@
+name: Use mocks to respond
+version: "2"
+testcases:
+  - name: Use basic mock with id
+    steps:
+      - type: http
+        method: POST
+        url: http://localhost:8081/mocks?reset=true
+        bodyFile: ../data/basic_mock_with_id.yml
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson.message ShouldEqual "Mocks registered successfully"
+
+      - type: http
+        method: GET
+        url: http://localhost:8080/test
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson.message ShouldEqual test
+
+      - type: http
+        method: GET
+        url: http://localhost:8081/mocks
+        assertions:
+          - result.bodyjson.__len__ ShouldEqual 1
+          - result.bodyjson.bodyjson0.state.id ShouldEqual 1
+
+      - type: http
+        method: POST
+        url: http://localhost:8081/mocks
+        bodyFile: ../data/basic_mock_with_id.yml
+        assertions:
+          - result.statuscode ShouldEqual 409


### PR DESCRIPTION
A solution that will fix. https://github.com/smocker-dev/smocker/issues/295

Allows users to define their mock IDs in stubs definitions with mockId.