### PR TITLE
test: replace flaky httpbin.org with a local go-httpbin for proxy tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,13 @@ VENOM=$(GOPATH)/bin/venom
 $(VENOM):
 	go install github.com/ovh/venom/cmd/venom@$(VENOMVERSION)
 
+# Local proxy target for the integration tests: a self-hosted httpbin (go-httpbin) so the
+# proxy mocks don't depend on the flaky public httpbin.org.
+GOHTTPBINVERSION:=v2.18.3
+GOHTTPBIN=$(GOPATH)/bin/go-httpbin
+$(GOHTTPBIN):
+	go install github.com/mccutchen/go-httpbin/v2/cmd/go-httpbin@$(GOHTTPBINVERSION)
+
 GOCOVMERGE=$(GOPATH)/bin/gocovmerge
 $(GOCOVMERGE):
 	go install github.com/wadey/gocovmerge@latest
@@ -90,14 +97,19 @@ test:
 	go test -v -race -coverprofile=$(COVERAGE_DIR)/test-cover.out ./server/...
 
 PID_FILE=/tmp/$(APPNAME).test.pid
+HTTPBIN_PID_FILE=/tmp/$(APPNAME).httpbin.pid
+PROXY_TARGET_PORT ?= 8090
 .PHONY: test-integration
-test-integration: $(VENOM) check-default-ports persistence
+test-integration: $(VENOM) $(GOHTTPBIN) check-default-ports persistence
 	mkdir -p $(COVERAGE_DIR)
 	go test -race -coverpkg="./..." -c . -o $(BUILD_DIR)/$(APPNAME).test
+	$(GOHTTPBIN) -port $(PROXY_TARGET_PORT) >/dev/null 2>&1 & echo $$! > $(HTTPBIN_PID_FILE)
 	SMOCKER_PERSISTENCE_DIRECTORY=./$(SESSIONS_DIR) $(BUILD_DIR)/$(APPNAME).test -test.coverprofile=$(COVERAGE_DIR)/test-integration-cover.out >/dev/null 2>&1 & echo $$! > $(PID_FILE)
 	sleep 5
-	$(VENOM) run tests/features/$(SUITE)
-	kill `cat $(PID_FILE)` 2> /dev/null || true
+	@ret=0; $(VENOM) run tests/features/$(SUITE) || ret=$$?; \
+		kill `cat $(PID_FILE)` 2>/dev/null || true; \
+		kill `cat $(HTTPBIN_PID_FILE)` 2>/dev/null || true; \
+		exit $$ret
 
 .PHONY: start-integration
 start-integration: $(VENOM)

--- a/tests/data/proxy_mock_list.yml
+++ b/tests/data/proxy_mock_list.yml
@@ -11,29 +11,29 @@
 - request:
     path: /redirect-to
   proxy:
-    host: https://httpbin.org
+    host: http://localhost:8090
 - request:
     path: /redirect-to
     headers:
       X-Follow-Redirect: "true"
   proxy:
-    host: https://httpbin.org
+    host: http://localhost:8090
     follow_redirect: true
 - request:
     path: /get
   proxy:
-    host: https://httpbin.org
+    host: http://localhost:8090
 - request:
     path: /get
     headers:
       X-Keep-Host: "true"
   proxy:
-    host: https://httpbin.org
+    host: http://localhost:8090
     keep_host: true
 - request:
     path: /headers
   proxy:
-    host: https://httpbin.org
+    host: http://localhost:8090
     headers:
       custom: "foobar"
       multi:

--- a/tests/features/set_mocks.yml
+++ b/tests/features/set_mocks.yml
@@ -165,10 +165,10 @@ testcases:
           - result.bodyjson.__len__ ShouldEqual 9
           - result.bodyjson.bodyjson8.proxy.host ShouldEqual https://jsonplaceholder.typicode.com
           - result.bodyjson.bodyjson7.proxy.host ShouldEqual https://jsonplaceholder.typicode.com
-          - result.bodyjson.bodyjson6.proxy.host ShouldEqual https://httpbin.org
-          - result.bodyjson.bodyjson5.proxy.host ShouldEqual https://httpbin.org
-          - result.bodyjson.bodyjson4.proxy.host ShouldEqual https://httpbin.org
-          - result.bodyjson.bodyjson3.proxy.host ShouldEqual https://httpbin.org
-          - result.bodyjson.bodyjson2.proxy.host ShouldEqual https://httpbin.org
+          - result.bodyjson.bodyjson6.proxy.host ShouldEqual http://localhost:8090
+          - result.bodyjson.bodyjson5.proxy.host ShouldEqual http://localhost:8090
+          - result.bodyjson.bodyjson4.proxy.host ShouldEqual http://localhost:8090
+          - result.bodyjson.bodyjson3.proxy.host ShouldEqual http://localhost:8090
+          - result.bodyjson.bodyjson2.proxy.host ShouldEqual http://localhost:8090
           - result.bodyjson.bodyjson1.proxy.host ShouldEqual https://self-signed.badssl.com
           - result.bodyjson.bodyjson0.proxy.host ShouldEqual https://self-signed.badssl.com

--- a/tests/features/use_mocks.yml
+++ b/tests/features/use_mocks.yml
@@ -273,21 +273,21 @@ testcases:
       #     - result.headers.location ShouldEqual https://smocker.dev/
       # - type: http
       #   method: GET
-      #   url: http://localhost:8080/redirect-to?url=https%3A%2F%2Fhttpbin.org%2Fget&status_code=302
+      #   url: http://localhost:8080/redirect-to?url=https%3A%2F%2Flocalhost:8090%2Fget&status_code=302
       #   headers:
       #     X-Follow-Redirect: "true"
       #     User-Agent: "foobar"
       #   no_follow_redirect: true
       #   assertions:
       #     - result.statuscode ShouldEqual 200
-      #     - result.bodyjson.url ShouldEqual https://httpbin.org/get
+      #     - result.bodyjson.url ShouldEqual https://localhost:8090/get
 
       - type: http
         method: GET
         url: http://localhost:8080/get
         assertions:
           - result.statuscode ShouldEqual 200
-          - result.bodyjson.headers.host ShouldEqual httpbin.org
+          - result.bodyjson.headers.host.host0 ShouldEqual localhost:8090
 
       - type: http
         method: GET
@@ -296,7 +296,7 @@ testcases:
           X-Keep-Host: "true"
         assertions:
           - result.statuscode ShouldEqual 200
-          - result.bodyjson.headers.host ShouldEqual localhost
+          - result.bodyjson.headers.host.host0 ShouldEqual localhost:8080
 
       - type: http
         method: GET
@@ -306,8 +306,9 @@ testcases:
           CuStOm: ShouldBeOverwritten
         assertions:
           - result.statuscode ShouldEqual 200
-          - result.bodyjson.headers.custom ShouldEqual foobar
-          - result.bodyjson.headers.multi ShouldEqual foo,baz
+          - result.bodyjson.headers.custom.custom0 ShouldEqual foobar
+          - result.bodyjson.headers.multi.multi0 ShouldEqual foo
+          - result.bodyjson.headers.multi.multi1 ShouldEqual baz
 
       - type: http
         method: GET

--- a/tests/serialization/mock_proxy_mock_list.golden.json
+++ b/tests/serialization/mock_proxy_mock_list.golden.json
@@ -51,7 +51,7 @@
       }
     },
     "proxy": {
-      "host": "https://httpbin.org",
+      "host": "http://localhost:8090",
       "delay": {}
     }
   },
@@ -75,7 +75,7 @@
       }
     },
     "proxy": {
-      "host": "https://httpbin.org",
+      "host": "http://localhost:8090",
       "delay": {},
       "follow_redirect": true
     }
@@ -92,7 +92,7 @@
       }
     },
     "proxy": {
-      "host": "https://httpbin.org",
+      "host": "http://localhost:8090",
       "delay": {}
     }
   },
@@ -116,7 +116,7 @@
       }
     },
     "proxy": {
-      "host": "https://httpbin.org",
+      "host": "http://localhost:8090",
       "delay": {},
       "keep_host": true
     }
@@ -133,7 +133,7 @@
       }
     },
     "proxy": {
-      "host": "https://httpbin.org",
+      "host": "http://localhost:8090",
       "delay": {},
       "headers": {
         "custom": [

--- a/tests/serialization/mock_proxy_mock_list.golden.yaml
+++ b/tests/serialization/mock_proxy_mock_list.golden.yaml
@@ -28,7 +28,7 @@
         matcher: ShouldMatch
         value: .*
   proxy:
-    host: https://httpbin.org
+    host: http://localhost:8090
 - request:
     path:
         matcher: ShouldEqual
@@ -41,7 +41,7 @@
             - matcher: ShouldEqual
               value: "true"
   proxy:
-    host: https://httpbin.org
+    host: http://localhost:8090
     follow_redirect: true
 - request:
     path:
@@ -51,7 +51,7 @@
         matcher: ShouldMatch
         value: .*
   proxy:
-    host: https://httpbin.org
+    host: http://localhost:8090
 - request:
     path:
         matcher: ShouldEqual
@@ -64,7 +64,7 @@
             - matcher: ShouldEqual
               value: "true"
   proxy:
-    host: https://httpbin.org
+    host: http://localhost:8090
     keep_host: true
 - request:
     path:
@@ -74,7 +74,7 @@
         matcher: ShouldMatch
         value: .*
   proxy:
-    host: https://httpbin.org
+    host: http://localhost:8090
     headers:
         custom:
             - foobar


### PR DESCRIPTION
## Summary

The proxy integration tests hit the public **httpbin.org**, which is unreliable in CI
(intermittent `503`s — it's been flaking the `test` job). This makes them hermetic by
running a self-hosted **go-httpbin** during `make test-integration` and pointing the proxy
mocks at it.

Notably, an external echo service **cannot** cover the `keep_host` case: forwarding the
original `Host` (which doesn't match the echo's domain) is rejected with `403` by their CDN.
A local target is the only way to keep that coverage.

## Changes
- **Makefile**: pinned `go-httpbin` (`v2.18.3`) tool, started on `:8090` for the duration of
  `test-integration` and stopped afterwards (even if venom fails).
- **Fixture & assertions**: proxy mocks target `http://localhost:8090`; venom assertions
  updated because go-httpbin returns header values as arrays (`headers.host.host0`,
  `custom.custom0`, `multi.multi0/1`); golden files regenerated. `jsonplaceholder` and
  `self-signed.badssl.com` targets are unchanged (only httpbin was flaky).

## Test plan
- Verified locally with venom (port-shifted to avoid the busy 8080): `set_mocks` and
  `use_mocks` fully green, including `Use-proxy-mock-list` (echo host, `keep_host`, `/headers`).
- Golden serialization test and `go test ./server/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
