### PR TITLE
fix(docker): make the embedded binary executable in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY build/smocker-${TARGETOS}-${TARGETARCH}${TARGETVARIANT} /smocker
+# --chmod: GitHub artifacts don't preserve the executable bit, so the downloaded binary the
+# deploy job packages is 0644 — force 0755 here or scratch can't exec it.
+COPY --chmod=0755 build/smocker-${TARGETOS}-${TARGETARCH}${TARGETVARIANT} /smocker
 # Run unprivileged (nobody); ports are >1024 and a mounted persistence dir must be writable by it.
 USER 65534:65534
 ENTRYPOINT ["/smocker"]


### PR DESCRIPTION
## Problem

The published multi-arch image (`v1.1.1-preview`) failed to start:

```
crun: the path `/smocker` exists but it is not executable: OCI permission denied
```

`/smocker` inside the image was `0644`. `actions/upload-artifact`/`download-artifact` don't preserve the Unix executable bit, so the binary the **deploy** job downloads and packages is `0644`, and `COPY` kept that mode into the `scratch` image, which then can't exec it.

The **build** job's smoke test didn't catch it because it builds the binary locally (`0755`) — it never exercises the artifact round-trip that the deploy job does.

## Fix

`COPY --chmod=0755` sets the mode at copy time, independent of the source file's bit — fixing both the artifact-based deploy build and local builds.

## Verified

Built the image from a deliberately `0644` binary with the fixed Dockerfile → `/smocker` is `0755` and the container starts (serves `/version` + the embedded UI + a mock round-trip). Confirmed the current published image is `0644` and reproduces the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
