### PR TITLE
ci(docker): smoke-test the image before publishing it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,14 @@ deploy-docker:
 	# Assemble and push the multi-arch image from the pre-built binaries. No compilation and no
 	# QEMU: every target stage is COPY-only (the cert stage runs on the build platform).
 	docker buildx create --use
+	# Smoke-test BEFORE publishing anything: build the native amd64 image locally (--load) from the
+	# exact downloaded artifact — which has lost its executable bit through the GitHub artifact
+	# round-trip — then run it and check it serves. Nothing is pushed unless this passes, so a
+	# broken image can never reach the registry (the build job's smoke can't catch this: it builds
+	# the binary locally, never from the artifact).
+	docker buildx build --load --platform linux/amd64 --tag $(DOCKER_IMAGE):$(DOCKER_TAG) .
+	$(MAKE) start-docker smoke-docker
+	docker rm -f $(APPNAME) >/dev/null 2>&1 || true
 ifdef IS_SEMVER
 	docker buildx build --push --platform $(DOCKER_PLATFORMS) --tag $(DOCKER_IMAGE):latest .
 endif


### PR DESCRIPTION
## What

Smoke-test the container image **before** publishing it, so a broken image can never reach the registry.

The deploy job now, in `make deploy-docker`:
1. builds the native `linux/amd64` image locally (`--load`) from the **downloaded artifact**,
2. runs it and checks it serves (`/version`, the embedded UI, and a mock round-trip),
3. only then pushes the multi-arch image.

## Why

The `build` job already smoke-tests an image, but it builds the binary **locally** — it never exercises the GitHub artifact round-trip that the deploy job does. That gap let a real bug ship: `actions/upload-artifact` doesn't preserve the executable bit, so the binary the deploy job packaged was `0644` and the published `scratch` image failed at startup with `/smocker ... not executable` (fixed in the Dockerfile via `COPY --chmod=0755`). This pre-push smoke closes the gap by testing the exact artifact that gets published.

Extends the docker smoke-testing from #68 to the publish path.

## Verified

`make -n deploy-docker` shows nothing is pushed before the smoke passes; locally, building the amd64 image from a deliberately `0644` binary and running the smoke succeeds (serves the UI + mock 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
