### PR TITLE
fix(server): create the default session atomically (no duplicate "Session #1")

### DIFF
--- a/server/services/mocks.go
+++ b/server/services/mocks.go
@@ -264,6 +264,16 @@ func (s *mocks) GetHistoryByPath(sessionID, filterPath string) (types.History, e
 }
 
 func (s *mocks) NewSession(name string) *types.Session {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.newSessionLocked(name)
+}
+
+// newSessionLocked appends a new session and returns it. The caller MUST hold s.mu: the default
+// name and the carried-over locked mocks are both derived from s.sessions, so the whole thing has
+// to happen in one critical section — otherwise two concurrent creators can read the same length
+// and both mint e.g. "Session #1" (the bug behind the flaky rename e2e test).
+func (s *mocks) newSessionLocked(name string) *types.Session {
 	if strings.TrimSpace(name) == "" {
 		name = fmt.Sprintf("Session #%d", len(s.sessions)+1)
 	}
@@ -275,20 +285,15 @@ func (s *mocks) NewSession(name string) *types.Session {
 		history = types.History{}
 	}
 
+	// Carry over the locked mocks from the current last session, reset for the new one.
 	mocks := types.Mocks{}
 	if len(s.sessions) > 0 {
-		session := s.GetLastSession()
-		s.mu.Lock()
-		for _, mock := range session.Mocks {
+		for _, mock := range s.sessions[len(s.sessions)-1].Mocks {
 			if mock.State.Locked {
 				mocks = append(mocks, mock.CloneAndReset())
 			}
 		}
-		s.mu.Unlock()
 	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	session := &types.Session{
 		ID:      types.NewID(),
@@ -346,12 +351,10 @@ func (s *mocks) DeleteSession(id string) error {
 
 func (s *mocks) GetLastSession() *types.Session {
 	s.mu.Lock()
-	if len(s.sessions) == 0 {
-		s.mu.Unlock()
-		s.NewSession("")
-		s.mu.Lock()
-	}
 	defer s.mu.Unlock()
+	if len(s.sessions) == 0 {
+		return s.newSessionLocked("").Clone()
+	}
 	return s.sessions[len(s.sessions)-1].Clone()
 }
 

--- a/server/services/mocks_test.go
+++ b/server/services/mocks_test.go
@@ -1,11 +1,37 @@
 package services
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/smocker-dev/smocker/server/types"
 	"gopkg.in/yaml.v3"
 )
+
+// TestGetLastSessionConcurrent guards the TOCTOU race that let concurrent callers each create a
+// default session (two "Session #1") when the list was empty — the source of the flaky "rename a
+// session" e2e test. Run under -race.
+func TestGetLastSessionConcurrent(t *testing.T) {
+	svc := NewMocks(nil, 0, NewPersistence(""))
+
+	const n = 50
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = svc.GetLastSession()
+		}()
+	}
+	close(start) // release all goroutines at once to maximize contention
+	wg.Wait()
+
+	if got := len(svc.GetSessions()); got != 1 {
+		t.Fatalf("concurrent GetLastSession on an empty service created %d sessions, want 1", got)
+	}
+}
 
 func mockFromYAML(t *testing.T, s string) *types.Mock {
 	t.Helper()


### PR DESCRIPTION
## Problem

The `e2e` job flaked on `main` (the merge of #315): the "rename a session" test failed with

```
strict mode violation: getByText('Session #1', { exact: true }) resolved to 2 elements
```

i.e. **two sessions named `Session #1`** existed at once.

## Root cause

`GetLastSession` auto-creates a default session when the list is empty, but it **released the lock between the empty-check and the creation**, and `NewSession` computed the `Session #N` name outside the lock:

```go
s.mu.Lock()
if len(s.sessions) == 0 {
    s.mu.Unlock()      // ← gap
    s.NewSession("")   // re-locks internally
    s.mu.Lock()
}
```

When the UI fires concurrent requests against an empty session list — the History page's parallel `GET /sessions` + `/history` + `/mocks` (+ autorefresh) right after **Reset Sessions** — two of them each see `len == 0` and each create a `Session #1`. Intermittent → flaky. Violates `PRINCIPLES.md` §3.7 (concurrency safety).

## Fix

Move the append into an unlocked `newSessionLocked` helper, called within a **single** critical section by both `NewSession` and `GetLastSession` (name + carried-over locked mocks are all derived from `s.sessions`, so they must be computed under the same lock). No behaviour change otherwise.

## Test

`TestGetLastSessionConcurrent` fires 50 concurrent `GetLastSession` calls on an empty service and asserts exactly one session is created. Verified it **fails on the old code** (`created 2 sessions, want 1`) and passes on the fix; the whole suite is green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
