### PR TITLE
fix(templates): apply delay from go_template_json dynamic responses

### DIFF
--- a/server/templates/go_template_test.go
+++ b/server/templates/go_template_test.go
@@ -1,0 +1,41 @@
+package templates
+
+import (
+	"testing"
+	"time"
+
+	"github.com/smocker-dev/smocker/server/types"
+)
+
+// TestGoTemplateJsonDelay reproduces #305: a delay written as duration strings ("10ms") in a
+// go_template_json dynamic response must be applied — it was previously silently dropped because
+// Delay.UnmarshalJSON only accepted numeric nanoseconds.
+func TestGoTemplateJsonDelay(t *testing.T) {
+	script := `{
+  "body": {"message": "request path {{.Request.Path}}"},
+  "headers": {"Content-Type": ["application/json"]},
+  "delay": {"min": "0", "max": "10ms"}
+}`
+	res, err := NewGoTemplateJsonEngine().Execute(types.Request{Path: "/test"}, script)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Delay.Min != 0 {
+		t.Errorf("delay.min = %v, want 0", res.Delay.Min)
+	}
+	if res.Delay.Max != 10*time.Millisecond {
+		t.Errorf("delay.max = %v, want 10ms", res.Delay.Max)
+	}
+}
+
+// TestGoTemplateJsonDelayScalar covers the single-value shorthand ("delay": "5ms").
+func TestGoTemplateJsonDelayScalar(t *testing.T) {
+	res, err := NewGoTemplateJsonEngine().Execute(types.Request{Path: "/test"},
+		`{"body": "hi", "delay": "5ms"}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Delay.Min != 5*time.Millisecond || res.Delay.Max != 5*time.Millisecond {
+		t.Errorf("delay = {%v, %v}, want {5ms, 5ms}", res.Delay.Min, res.Delay.Max)
+	}
+}

--- a/server/types/mock.go
+++ b/server/types/mock.go
@@ -165,24 +165,57 @@ type Delay struct {
 }
 
 func (d *Delay) UnmarshalJSON(data []byte) error {
-	var s time.Duration
-	if err := json.Unmarshal(data, &s); err == nil {
-		d.Min = s
-		d.Max = s
+	// Scalar form: a single duration applied to both bounds.
+	if v, ok, err := parseJSONDuration(data); err != nil {
+		return err
+	} else if ok {
+		d.Min, d.Max = v, v
 		return d.validate()
 	}
 
+	// Object form: {"min": ..., "max": ...}. Each bound is a duration string ("10ms") or a number
+	// of nanoseconds — the same shapes the Lua and go_template_yaml engines already accept.
 	var res struct {
-		Min time.Duration `json:"min"`
-		Max time.Duration `json:"max"`
+		Min json.RawMessage `json:"min"`
+		Max json.RawMessage `json:"max"`
 	}
-
 	if err := json.Unmarshal(data, &res); err != nil {
 		return err
 	}
-	d.Min = res.Min
-	d.Max = res.Max
+	if len(res.Min) > 0 {
+		v, _, err := parseJSONDuration(res.Min)
+		if err != nil {
+			return err
+		}
+		d.Min = v
+	}
+	if len(res.Max) > 0 {
+		v, _, err := parseJSONDuration(res.Max)
+		if err != nil {
+			return err
+		}
+		d.Max = v
+	}
 	return d.validate()
+}
+
+// parseJSONDuration reads a JSON scalar as a duration: a string like "10ms" (time.ParseDuration)
+// or a number of nanoseconds. ok is false when the value is not a scalar (e.g. an object), so the
+// caller can fall back to the {min, max} form.
+func parseJSONDuration(data []byte) (time.Duration, bool, error) {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return 0, false, err
+	}
+	switch x := v.(type) {
+	case string:
+		dur, err := time.ParseDuration(x)
+		return dur, true, err
+	case float64:
+		return time.Duration(int64(x)), true, nil
+	default:
+		return 0, false, nil
+	}
 }
 
 func (d *Delay) UnmarshalYAML(unmarshal func(interface{}) error) error {


### PR DESCRIPTION
Fixes #305.

## Problem

A `delay` written as duration strings in a **`go_template_json`** dynamic response was silently ignored — the response returned immediately — while the same mock worked under `lua`:

```yaml
dynamic_response:
  engine: go_template_json
  script: >
    { "body": {...}, "delay": { "min": "0", "max": "10ms" } }
```

## Root cause

`Delay.UnmarshalJSON` only accepted **numeric nanoseconds**, not duration strings like `"10ms"`. The Lua engine pre-parses durations (`time.ParseDuration`) and `go_template_yaml` happens to accept the string form, but `go_template_json` feeds the raw JSON straight to `Delay.UnmarshalJSON`, which errored on the string. `goTemplateJsonEngine.Execute` **logs that error but doesn't return it**, so the delay was dropped as `{0, 0}` and the mock answered with no delay.

## Fix

Parse each delay bound as **either a duration string** (`time.ParseDuration`) **or a number of nanoseconds**, matching the Lua/yaml engines. Marshalling is unchanged (still numeric nanoseconds), so the on-disk mock format is unaffected.

## Verified

- New engine tests: object form `{min,max}` **and** scalar shorthand `"5ms"` parse correctly.
- Golden serialization + JSON-schema tests unchanged; full server suite green.
- Runtime: a `go_template_json` mock with `delay {min:300ms, max:300ms}` now responds in ~0.30s (was ~0s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
