### PR TITLE
feat(api): return the target session from POST /mocks

### DIFF
--- a/server/handlers/admin.go
+++ b/server/handlers/admin.go
@@ -78,8 +78,17 @@ func (a *Admin) AddMocks(c echo.Context) error {
 		}
 	}
 
+	// Return the target session (id + name) so callers — shell scripts especially — can chain a
+	// GET /mocks?session=<id> without a separate GET /sessions lookup. Session names are not a
+	// reliable key (they need not be unique); the opaque id is.
+	session, err := a.mocksServices.GetSessionByID(sessionID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
 	return c.JSON(http.StatusOK, echo.Map{
 		"message": "Mocks registered successfully",
+		"session": session.Summarize(),
 	})
 }
 

--- a/tests/features/set_mocks.yml
+++ b/tests/features/set_mocks.yml
@@ -12,6 +12,9 @@ testcases:
         assertions:
           - result.statuscode ShouldEqual 200
           - result.bodyjson.message ShouldEqual "Mocks registered successfully"
+          # POST /mocks returns the target session so callers can chain GET /mocks?session=<id>.
+          - result.bodyjson.session.id ShouldNotBeEmpty
+          - result.bodyjson.session.name ShouldNotBeEmpty
 
       - type: http
         method: GET


### PR DESCRIPTION
Relates to #312.

## What

`POST /mocks` now returns the target **session** (`id` + `name` + `date`) alongside the existing message:

```jsonc
{
  "message": "Mocks registered successfully",
  "session": { "id": "W0dArqgEPE4m", "name": "my-suite", "date": "..." }
}
```

## Why

Registering mocks (optionally creating a session via `?newSession=<name>`) previously returned only a message, with no session id — so a caller, especially a shell script, had no handle to then fetch the mocks it just registered. It had to `GET /sessions` and guess by name, which isn't reliable (session names need not be unique; the opaque id is the key — see `PRINCIPLES.md` §3.6).

Now the flow is a clean chain:

```sh
sid=$(curl -s -XPOST "$SMOCKER/mocks?newSession=my-suite" --data-binary @mocks.yml | jq -r .session.id)
curl -s "$SMOCKER/mocks?session=$sid"
```

## Compatibility

Purely additive — the `message` field is unchanged, so existing clients are unaffected.

## Verified

- Unit + golden/schema tests green; a venom assertion covers `session.id` / `session.name` in the response.
- Runtime: `POST /mocks?newSession=my-suite` returns the session id, and `GET /mocks?session=<id>` returns the registered mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
